### PR TITLE
【Fixed】'rails g'コマンドを実行した際、assetsファイル、helperファイルが作成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,25 +2,15 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Smallstep
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.geneators do |g|
+      g.assets false
+      g.helper false
+    end
 
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
   end
 end


### PR DESCRIPTION
config/application.rbを編集し、railg gを実行した際に不要なファイルを生成しなようにした。

bundle update を実行し、gemファイルを更新。git hubのアラートを消すため。