### PR TITLE
【Fixed】rake db:migrateを実行。taskテーブルの作成

### DIFF
--- a/db/migrate/20180306190553_create_tasks.rb
+++ b/db/migrate/20180306190553_create_tasks.rb
@@ -1,6 +1,8 @@
 class CreateTasks < ActiveRecord::Migration
   def change
     create_table :tasks do |t|
+      t.string :todo
+      t.string :deadline
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180306190553) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string   "todo"
+    t.string   "deadline"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
rake db:createを実行した際、以下のエラーが発生。
FATAL:  database files are incompatible with server
DETAIL:  The data directory was initialized by PostgreSQL version 9.5, which is not compatible with this version 10.3.

以下のリンクを参照。
https://qiita.com/blueplanet/items/58e511daa02b5684ec1d

・サービスを停止する
launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
・10.3バージョンのデータフォルダを作成する
initdb /usr/local/var/postgres10.3 -E utf8
・アップグレードを実行する
pg_upgrade \
-d /usr/local/var/postgres \
-D /usr/local/var/postgres10.3 \
-b /usr/local/Cellar/postgresql/9.5.4_1/bin/ \
-B /usr/local/Cellar/postgresql/10.3/bin/ \
-v
・前回異常終了だった場合はpidファイルが残されているので、それを削除する（今回は大丈夫だった）
rm /usr/local/var/postgres/postmaster.pid
・データフォルダを変更
cd /usr/local/var
mv postgres postgres9.5.4_1
mv postgres10.3 postgres
・サービスを起動する
launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
・下記コマンドでアップグレード結果を確認
psql postgres -c "select version()"
psql -l
・クリーンアップ
brew cleanup postgresql
gem uninstall pg #すべてのバージョンを削除する
gem install pg

・bundle install
・rake db:create
・rake db:migrate